### PR TITLE
[Fix] Wrong message when succesfully deleting an account

### DIFF
--- a/lib/features/account/presentation/pages/add/add_account_page.dart
+++ b/lib/features/account/presentation/pages/add/add_account_page.dart
@@ -120,7 +120,7 @@ class AccountPageState extends State<AccountPage> {
               context.showMaterialSnackBar(
                 isAccountAddOrUpdate
                     ? context.loc.addedAccount
-                    : context.loc.updateAccount,
+                    : context.loc.updatedAccount,
                 backgroundColor: context.primaryContainer,
                 color: context.onPrimaryContainer,
               );


### PR DESCRIPTION
When deleting an account, the wrong text is shown in the snackbar pop-up.